### PR TITLE
Remove duplicated mouse_click plays on key press macros

### DIFF
--- a/iw4x/iw4x_00/ui_mp/menu_xboxlive_lobby.menu
+++ b/iw4x/iw4x_00/ui_mp/menu_xboxlive_lobby.menu
@@ -153,8 +153,7 @@
 	ON_MENU_KEY_K_APAD_RIGHT
 
 #define ON_MENU_KEY_K_F1 \
-	open											"popup_summary"; \
-	play											CHOICE_CLICK_SOUND;
+	open											"popup_summary";
 
 {
 	menuDef

--- a/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
+++ b/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
@@ -24,7 +24,6 @@
 	close															self;
 
 #define ON_MENU_KEY_F5 \
-	play															CHOICE_CLICK_SOUND; \
 	uiScript														"RefreshServers";
 
 #define ON_MENU_KEY_ENTER \


### PR DESCRIPTION
See definition of macro:
```
#define MENU_EXEC_KEYINT(keyIntArg, execArg) \
	execKeyInt keyIntArg \
	{ \
		play										CHOICE_CLICK_SOUND; \
		execArg										\
	}
```

This makes any handler that uses this or `MENU_EXEC_KEY` and still play the sound themselves duplicate the sound.