### PR TITLE
Add zonebuilder-wrapper

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -35,7 +35,7 @@ Write-Host "Done copying zone files.`n"
 
 # Create iw4x_00.iwd
 for ($i = 0; $i -lt 6; $i++)
-{ 
+{
     ${archName} = ("iw4x_{0:D2}" -f $i)
     Write-Host "Compressing ${archName}.zip..."
     Compress-Archive -Path "${rawFilesPath}\release\temp\iw4x\${archName}\*" -DestinationPath "${rawFilesPath}\release\temp\iw4x\${archName}.zip"
@@ -45,6 +45,13 @@ for ($i = 0; $i -lt 6; $i++)
     Remove-Item -Recurse "${rawFilesPath}\release\temp\iw4x\${archName}"
     Write-Host "Finished compressing ${archName}.iwd`n"
 }
+
+Write-Host "Downloading latest zonebuilder-wrapper"
+Invoke-WebRequest -Uri "https://github.com/mxve/zonebuilder-wrapper/releases/latest/download/zonebuilder-i686-pc-windows-msvc.zip" -OutFile "${rawFilesPath}\release\temp\zonebuilder.zip"
+Write-Host "Unpacking ${rawFilesPath}\release\temp\"
+Expand-Archive -LiteralPath "${rawFilesPath}\release\temp\zonebuilder.zip" -DestinationPath "${rawFilesPath}\release\temp\"
+Write-Host "Removing ${rawFilesPath}\release\temp\zonebuilder.zip"
+Remove-Item "${rawFilesPath}\release\temp\zonebuilder.zip"
 
 # Create release.zip
 if (Test-Path -Path "${rawFilesPath}\release\release.zip") {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,64 +1,42 @@
 #!/bin/bash
 
-sudo apt update >> /dev/null && sudo apt install zip -y >> /dev/null # Ensure zip is up to date.
+# set work_dir to the parent of this scripts location
+work_dir=$(dirname `cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd`)
+iwd_files=( "iw4x_00" "iw4x_01" "iw4x_02" "iw4x_03" "iw4x_04" "iw4x_05" )
 
-cd iw4x/
+# ensure dependencies are installed
+sudo apt update >> /dev/null && sudo apt install zip curl -y >> /dev/null
 
-# maybe this should be... a for loop instead
+# create release dir
+mkdir $work_dir/release
 
-# iw4x_00
-cd iw4x_00/
-zip -r iw4x_00.iwd *
-mv iw4x_00.iwd ../
-cd ..
-rm -rf iw4x_00/
+# copy artifacts to release dir
+cp iw4x.exe $work_dir/release/
+cp iw4sp.exe $work_dir/release/
+cp -r $work_dir/zone/ $work_dir/release/
+cp -r $work_dir/iw4x/ $work_dir/release/
 
-# iw4x_01
-cd iw4x_01/
-zip -r iw4x_01.iwd *
-mv iw4x_01.iwd ../
-cd ..
-rm -rf iw4x_01/
+# zip iwd_files
+for iwd in "${iwd_files[@]}"; do
+    pushd $work_dir/release/iw4x/$iwd
+    zip -r $iwd.zip *
+    mv $iwd.zip $work_dir/release/iw4x/$iwd.iwd
+    popd
+    rm -r $work_dir/release/iw4x/$iwd
+done
 
-# iw4x_02
-cd iw4x_02/
-zip -r iw4x_02.iwd *
-mv iw4x_02.iwd ../
-cd ..
-rm -rf iw4x_02/
-
-# iw4x_03
-cd iw4x_03/
-zip -r iw4x_03.iwd *
-mv iw4x_03.iwd ../
-cd ..
-rm -rf iw4x_03/
-
-# iw4x_04
-cd iw4x_04/
-zip -r iw4x_04.iwd *
-mv iw4x_04.iwd ../
-cd ..
-rm -rf iw4x_04/
-
-
-# iw4x_05
-cd iw4x_05/
-zip -r iw4x_05.iwd *
-mv iw4x_05.iwd ../
-cd ..
-rm -rf iw4x_05/
-
-cd ..
-
-# zonebuilder-wrapper
+# add zonebuilder-wrapper
+pushd $work_dir/release/
 curl -L https://github.com/mxve/zonebuilder-wrapper/releases/latest/download/zonebuilder-i686-pc-windows-msvc.zip -o zonebuilder.zip
 unzip zonebuilder.zip
 rm zonebuilder.zip
+popd
 
-# Cleanup
-rm LICENSE
-rm README.md
-rm -rf .github
-rm -rf scripts
+# create release.zip from release dir
+pushd $work_dir/release/
 zip -r release.zip *
+mv release.zip $work_dir
+popd
+
+# cleanup
+rm -r release

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,7 +10,7 @@ cd iw4x/
 cd iw4x_00/
 zip -r iw4x_00.iwd *
 mv iw4x_00.iwd ../
-cd .. 
+cd ..
 rm -rf iw4x_00/
 
 # iw4x_01
@@ -49,8 +49,14 @@ mv iw4x_05.iwd ../
 cd ..
 rm -rf iw4x_05/
 
-# Cleanup
 cd ..
+
+# zonebuilder-wrapper
+curl -L https://github.com/mxve/zonebuilder-wrapper/releases/latest/download/zonebuilder-i686-pc-windows-msvc.zip -o zonebuilder.zip
+unzip zonebuilder.zip
+rm zonebuilder.zip
+
+# Cleanup
 rm LICENSE
 rm README.md
 rm -rf .github


### PR DESCRIPTION
- **Integrated [zonebuilder-wrapper](https://github.com/mxve/zonebuilder-wrapper/)** into release scripts
- **Fully rewritten `release.sh`:**
  - Now only includes the necessary files for the release
  - Reduced redundancy in the script
  - Ensures that original files remain untouched

The source code for `zonebuilder.exe` is available at [mxve/zonebuilder-wrapper](https://github.com/mxve/zonebuilder-wrapper/). This executable runs `iw4x.exe` with the `-zonebuilder` argument, along with any additional passed arguments. This update is intended to partially address [iw4x-client#136](https://github.com/iw4x/iw4x-client/issues/136), focusing on improving the discoverability and usability of Zonebuilder.