### PR TITLE
Add Load Mod button to server list; modded stats warning

### DIFF
--- a/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
+++ b/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
@@ -59,7 +59,7 @@
 		BUTTON_FOOTER_VIS(-210, 135, "addFavorite", "@MENU_ADD_TO_FAVORITES_CAPS", uiScript "CreateListFavorite", when(dvarInt("ui_netSource") != 2))
 		BUTTON_FOOTER_VIS(-210, 135, "delFavorite", "@MENU_DEL_FAVORITE_CAPS", uiScript "DeleteFavorite", when(dvarInt("ui_netSource") == 2))
 		BUTTON_FOOTER(-65, 85, "passwordenter", "@MENU_PASSWORD_CAPS", open "popup_joinpassword";)
-		BUTTON_FOOTER(25, 95, "serverinfo", "", open "serverinfo_popmenu";)
+		BUTTON_FOOTER(25, 95, "serverinfo", "@MENU_SERVER_INFO_CAPS", open "serverinfo_popmenu";)
 		BUTTON_FOOTER(130, 80, "loadmod", "@MENU_LOAD_MOD_CAPS", uiScript "LoadMod";)
 		BUTTON_FOOTER(215, 95, "joinserver", "@MENU_JOIN_SERVER_CAPS", uiScript "JoinServer";)
 	}

--- a/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
+++ b/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
@@ -60,7 +60,7 @@
 		BUTTON_FOOTER_VIS(-210, 135, "delFavorite", "@MENU_DEL_FAVORITE_CAPS", uiScript "DeleteFavorite", when(dvarInt("ui_netSource") == 2))
 		BUTTON_FOOTER(-65, 85, "passwordenter", "@MENU_PASSWORD_CAPS", open "popup_joinpassword";)
 		BUTTON_FOOTER(25, 95, "serverinfo", "@MENU_SERVER_INFO_CAPS", open "serverinfo_popmenu";)
-		BUTTON_FOOTER(130, 80, "loadmod", "@MENU_LOAD_MOD_CAPS", uiScript "LoadMod";)
+		BUTTON_FOOTER(130, 80, "loadmod", "@MENU_LOAD_MOD_CAPS", uiScript "DownloadServerMod";)
 		BUTTON_FOOTER(215, 95, "joinserver", "@MENU_JOIN_SERVER_CAPS", uiScript "JoinServer";)
 	}
 }

--- a/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
+++ b/iw4x/iw4x_00/ui_mp/pc_join_unranked.menu
@@ -55,11 +55,12 @@
 
 		ITEM_MENU_TITLE_VIS(MENU_TITLE, 1)
 		
-		BUTTON_FOOTER(-310, 100, "back", "@PLATFORM_BACK_CAPS", ON_MENU_ESC)
-		BUTTON_FOOTER_VIS(-194, 140, "addFavorite", "@MENU_ADD_TO_FAVORITES_CAPS", uiScript "CreateListFavorite", when(dvarInt("ui_netSource") != 2))
-		BUTTON_FOOTER_VIS(-194, 140, "delFavorite", "@MENU_DEL_FAVORITE_CAPS", uiScript "DeleteFavorite", when(dvarInt("ui_netSource") == 2))
-		BUTTON_FOOTER(-34, 100, "passwordenter", "@MENU_PASSWORD_CAPS", open "popup_joinpassword";)
-		BUTTON_FOOTER(86, 100, "serverinfo", "@MENU_SERVER_INFO_CAPS", open "serverinfo_popmenu";)
-		BUTTON_FOOTER(206, 100, "joinserver", "@MENU_JOIN_SERVER_CAPS", uiScript "JoinServer";)
+		BUTTON_FOOTER(-310, 95, "back", "@PLATFORM_BACK_CAPS", ON_MENU_ESC)
+		BUTTON_FOOTER_VIS(-210, 135, "addFavorite", "@MENU_ADD_TO_FAVORITES_CAPS", uiScript "CreateListFavorite", when(dvarInt("ui_netSource") != 2))
+		BUTTON_FOOTER_VIS(-210, 135, "delFavorite", "@MENU_DEL_FAVORITE_CAPS", uiScript "DeleteFavorite", when(dvarInt("ui_netSource") == 2))
+		BUTTON_FOOTER(-65, 85, "passwordenter", "@MENU_PASSWORD_CAPS", open "popup_joinpassword";)
+		BUTTON_FOOTER(25, 95, "serverinfo", "", open "serverinfo_popmenu";)
+		BUTTON_FOOTER(130, 80, "loadmod", "@MENU_LOAD_MOD_CAPS", uiScript "LoadMod";)
+		BUTTON_FOOTER(215, 95, "joinserver", "@MENU_JOIN_SERVER_CAPS", uiScript "JoinServer";)
 	}
 }

--- a/iw4x/iw4x_00/ui_mp/stats_mod_warning.menu
+++ b/iw4x/iw4x_00/ui_mp/stats_mod_warning.menu
@@ -104,7 +104,7 @@
 			forecolor 0 0 0 1
 			background "drop_shadow_tl"
 			textscale 0.55
-			visible when ( 1 )
+			visible 1
 		}
 		itemDef
 		{
@@ -115,7 +115,7 @@
 			forecolor 0 0 0 1
 			background "drop_shadow_t"
 			textscale 0.55
-			visible when ( 1 )
+			visible 1
 		}
 		itemDef
 		{
@@ -126,7 +126,7 @@
 			forecolor 0 0 0 1
 			background "drop_shadow_tr"
 			textscale 0.55
-			visible when ( 1 )
+			visible 1
 		}
 		itemDef
 		{
@@ -138,7 +138,7 @@
 			background "drop_shadow_br"
 			textscale 0.55
 			exp rect y ( 204 )
-			visible when ( 1 )
+			visible 1
 		}
 		itemDef
 		{
@@ -150,7 +150,7 @@
 			background "drop_shadow_b"
 			textscale 0.55
 			exp rect y ( 204 )
-			visible when ( 1 )
+			visible 1
 		}
 		itemDef
 		{
@@ -162,7 +162,7 @@
 			background "drop_shadow_bl"
 			textscale 0.55
 			exp rect y ( 204 )
-			visible when ( 1 )
+			visible 1
 		}
 		itemDef
 		{
@@ -227,7 +227,7 @@
 			textalignx 4
 			textscale 0.375
 			text "@MENU_MODDED_STATS_WARNING_YES"
-			visible when ( 1 )
+			visible 1
 			action
 			{
 				play "mouse_click";
@@ -266,7 +266,7 @@
 			textalignx 4
 			textscale 0.375
 			text "@MENU_MODDED_STATS_WARNING_NO"
-			visible when ( 1 )
+			visible 1
 			action
 			{
 				play "mouse_click";

--- a/iw4x/iw4x_00/ui_mp/stats_mod_warning.menu
+++ b/iw4x/iw4x_00/ui_mp/stats_mod_warning.menu
@@ -1,0 +1,293 @@
+{
+	menuDef
+	{
+		name "stats_mod_warning"
+		rect -430 -102 860 204 2 2
+		popup
+		legacySplitScreenScale
+		style 1
+		forecolor 1 1 1 1
+		backcolor 1 1 1 1
+		background "white"
+		focuscolor 1 1 1 1
+		onClose
+		{
+			setLocalVarInt "ui_centerPopup" ( 0 );
+		}
+		onEsc
+		{
+			close self;
+		}
+		itemDef
+		{
+			rect -1004 -582 3416 1920 2 2
+			decoration
+			visible 1
+			style 1
+			forecolor 1 1 1 1
+			backcolor 1 1 1 1
+			background "xpbar_stencilbase"
+			textscale 0.55
+		}
+		itemDef
+		{
+			rect 0 0 860 204 2 2
+			decoration
+			visible 1
+			style 1
+			forecolor 1 1 1 1
+			backcolor 0.5 0.5 0.5 1
+			background "white"
+			textscale 0.55
+		}
+		itemDef
+		{
+			rect -150 -44 1708 480 2 9
+			decoration
+			visible 1
+			style 3
+			forecolor 1 1 1 0.75
+			background "mw2_popup_bg_fogstencil"
+			textscale 0.55
+			exp rect x ( 0 - ( ( float( milliseconds( ) % 60000 ) / 60000 ) * ( 854 ) ) )
+		}
+		itemDef
+		{
+			rect -150 -44 -1708 -480 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0.85 0.85 0.85 1
+			background "mw2_popup_bg_fogscroll"
+			textscale 0.55
+			exp rect x ( 0 - ( ( float( milliseconds( ) % 60000 ) / 60000 ) * ( 854 ) ) )
+		}
+		itemDef
+		{
+			rect 0 0 860 0 2 9
+			decoration
+			visible 1
+			style 3
+			forecolor 1 1 1 1
+			background "mockup_popup_bg_stencilfill"
+			textscale 0.55
+			exp rect h ( ( 84 + 2 * 60 ) )
+		}
+		itemDef
+		{
+			rect -150 -44 -1708 -480 2 9
+			decoration
+			visible 1
+			style 3
+			forecolor 1 1 1 0.75
+			background "mw2_popup_bg_fogstencil"
+			textscale 0.55
+			exp rect x ( ( 0 - 854 ) + ( ( float( milliseconds( ) % 50000 ) / 50000 ) * ( 854 ) ) )
+		}
+		itemDef
+		{
+			rect -150 -44 -1708 -480 2 9
+			decoration
+			visible 1
+			style 3
+			forecolor 0.85 0.85 0.85 1
+			background "mw2_popup_bg_fogscroll"
+			textscale 0.55
+			exp rect x ( ( 0 - 854 ) + ( ( float( milliseconds( ) % 50000 ) / 50000 ) * ( 854 ) ) )
+		}
+		itemDef
+		{
+			rect -64 -64 64 64 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0 0 0 1
+			background "drop_shadow_tl"
+			textscale 0.55
+			visible when ( 1 )
+		}
+		itemDef
+		{
+			rect 0 -64 860 64 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0 0 0 1
+			background "drop_shadow_t"
+			textscale 0.55
+			visible when ( 1 )
+		}
+		itemDef
+		{
+			rect 860 -64 64 64 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0 0 0 1
+			background "drop_shadow_tr"
+			textscale 0.55
+			visible when ( 1 )
+		}
+		itemDef
+		{
+			rect 860 0 64 64 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0 0 0 1
+			background "drop_shadow_br"
+			textscale 0.55
+			exp rect y ( 204 )
+			visible when ( 1 )
+		}
+		itemDef
+		{
+			rect 0 0 860 64 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0 0 0 1
+			background "drop_shadow_b"
+			textscale 0.55
+			exp rect y ( 204 )
+			visible when ( 1 )
+		}
+		itemDef
+		{
+			rect -64 0 64 64 2 2
+			decoration
+			visible 1
+			style 3
+			forecolor 0 0 0 1
+			background "drop_shadow_bl"
+			textscale 0.55
+			exp rect y ( 204 )
+			visible when ( 1 )
+		}
+		itemDef
+		{
+			rect 0 0 860 24 2 2
+			decoration
+			visible 1
+			style 1
+			forecolor 1 1 1 1
+			background "gradient_fadein"
+			textfont 9
+			textalign 5
+			textalignx -4
+			textscale 0.375
+			text "@MENU_MODDED_STATS_WARNING_TITLE"
+		}
+		itemDef
+		{
+			rect 286 22 292 20 2 2
+			decoration
+			autowrapped
+			visible 1
+			group "mw2_button"
+			forecolor 1 1 1 0.65
+			disablecolor 0.6 0.55 0.55 1
+			background "menu_button_selection_bar"
+			type 1
+			textFont 3
+			textAlign 4
+			textScale 0.375
+			exp text("@MENU_MODDED_STATS_WARNING")
+			action
+			{
+				play "mouse_click";
+			}
+			onFocus
+			{
+				play "mouse_over";
+				setItemColor self backcolor 0 0 0 1;
+				setLocalVarBool "ui_menuAButton" ( 1 );
+				setLocalVarFloat "ui_popupYPos" ( getfocuseditemy( ) );
+			}
+			leaveFocus
+			{
+				setItemColor self backcolor 0 0 0 "0.0";
+				setLocalVarString "ui_hint_text" ( "@NULL_EMPTY" );
+				setLocalVarBool "ui_menuAButton" ( 0 );
+			}
+		}
+		itemDef
+		{
+			name "reset_button"
+			rect 286 164 292 20 2 2
+			visible 1
+			group "mw2_popup_button"
+			style 1
+			forecolor 1 1 1 1
+			disablecolor 0.6 0.55 0.55 1
+			background "popup_button_selection_bar_flipped"
+			type 1
+			textfont 3
+			textalign 4
+			textalignx 4
+			textscale 0.375
+			text "@MENU_MODDED_STATS_WARNING_YES"
+			visible when ( 1 )
+			action
+			{
+				play "mouse_click";
+				exec "vid_restart";
+				close self;
+			}
+			onFocus
+			{
+				play "mouse_over";
+				if ( dvarstring( "gameMode" ) != "mp" )
+				{
+					setItemColor "mw2_popup_button" backcolor 0 0 0 0;
+				}
+				setItemColor self backcolor 0 0 0 1;
+				setLocalVarBool "ui_popupAButton" ( 1 );
+			}
+			leaveFocus
+			{
+				setItemColor self backcolor 1 1 1 0;
+				setLocalVarBool "ui_popupAButton" ( 0 );
+			}
+		}
+		itemDef
+		{
+			name "cancel_button"
+			rect 286 184 292 20 2 2
+			visible 1
+			group "mw2_popup_button"
+			style 1
+			forecolor 1 1 1 1
+			disablecolor 0.6 0.55 0.55 1
+			background "popup_button_selection_bar_flipped"
+			type 1
+			textfont 3
+			textalign 4
+			textalignx 4
+			textscale 0.375
+			text "@MENU_MODDED_STATS_WARNING_NO"
+			visible when ( 1 )
+			action
+			{
+				play "mouse_click";
+				exec "vid_restart; reconnect";
+				close self;
+			}
+			onFocus
+			{
+				play "mouse_over";
+				if ( dvarstring( "gameMode" ) != "mp" )
+				{
+					setItemColor "mw2_popup_button" backcolor 0 0 0 0;
+				}
+				setItemColor self backcolor 0 0 0 1;
+				setLocalVarBool "ui_popupAButton" ( 1 );
+			}
+			leaveFocus
+			{
+				setItemColor self backcolor 1 1 1 0;
+				setLocalVarBool "ui_popupAButton" ( 0 );
+			}
+		}
+	}
+}

--- a/raw/english/iw4x_localized_english.json
+++ b/raw/english/iw4x_localized_english.json
@@ -173,6 +173,8 @@
 
     "MENU_LAGOMETER": "Show Lagometer",
 
+    "MENU_LOAD_MOD_CAPS": "LOAD MOD",
+
     "MENU_LOADING_MAPS": "Loading map selection...",
 
     "MENU_LOCKON_ENABLED": "Enable lockon aim assist",

--- a/raw/english/iw4x_localized_english.json
+++ b/raw/english/iw4x_localized_english.json
@@ -185,6 +185,14 @@
 
     "MENU_MAXPACKETS": "Max. packets per frame",
 
+    "MENU_MODDED_STATS_WARNING_TITLE": "Setup stats?",
+
+    "MENU_MODDED_STATS_WARNING": "You are joining a modded server for the first time, ^1you will start at rank 1 with default classes ^7unless you set them up now.\n\nLater you can edit your classes by loading the servers mod from ^4Mods ^7on the main menu, or using the ^4Load Mod ^7button.",
+
+    "MENU_MODDED_STATS_WARNING_NO": "No, continue with default stats",
+
+    "MENU_MODDED_STATS_WARNING_YES": "Yes, take me to the main menu",
+
     "MENU_MODS": "Mods",
 
     "MENU_MODS_CAPS": "MODS",

--- a/raw/russian/iw4x_localized_russian.str
+++ b/raw/russian/iw4x_localized_russian.str
@@ -338,6 +338,18 @@ LANG_ENGLISH        "Maximum FPS"
 REFERENCE           MENU_MAXPACKETS
 LANG_ENGLISH        "Max. packets per frame"
 
+REFERENCE           MENU_MODDED_STATS_WARNING_TITLE
+LANG_ENGLISH        "Setup stats?"
+
+REFERENCE           MENU_MODDED_STATS_WARNING
+LANG_ENGLISH        "You are joining a modded server for the first time, ^1you will start at rank 1 with default classes ^7unless you set them up now.\n\nLater you can edit your classes by loading the servers mod from ^4Mods ^7on the main menu, or using the ^4Load Mod ^7button."
+
+REFERENCE           MENU_MODDED_STATS_WARNING_NO
+LANG_ENGLISH        "No, continue with default stats"
+
+REFERENCE           MENU_MODDED_STATS_WARNING_YES
+LANG_ENGLISH        "Yes, take me to the main menu"
+
 REFERENCE           MENU_MODS
 LANG_ENGLISH        "Mods"
 

--- a/raw/russian/iw4x_localized_russian.str
+++ b/raw/russian/iw4x_localized_russian.str
@@ -308,6 +308,9 @@ LANG_ENGLISH        "JOIN SERVER"
 REFERENCE           MENU_LAGOMETER
 LANG_ENGLISH        "Show Lagometer"
 
+REFERENCE           MENU_LOAD_MOD_CAPS
+LANG_ENGLISH        "LOAD MODS"
+
 REFERENCE           MENU_LOADING_MAPS
 LANG_ENGLISH        "Loading map selection..."
 


### PR DESCRIPTION
This PR adds a "LOAD MOD" button to the server list, which allows players to load a mod without fully connecting to a server.
It also displays a warning when joining a modded server for the first time, allowing the player to go back to the main menu to unlockall/setup classes.
The goal is to make class setup and customizations easier.

Requires https://github.com/iw4x/iw4x-client/pull/253

![image](https://github.com/user-attachments/assets/6ee0f8a8-872b-49fd-98fa-4cb5fd7c3c77)
![image](https://github.com/user-attachments/assets/fc0b0537-3523-4bb1-86b5-84f2a5fba6e7)

