### PR TITLE
Remove C bombsite from MW3 maps in Demolition.

### DIFF
--- a/iw4x/iw4x_00/maps/mp/gametypes/dd.gsc
+++ b/iw4x/iw4x_00/maps/mp/gametypes/dd.gsc
@@ -495,6 +495,17 @@ bombs()
 	{
 		trigger = bombZones[index];
 		visuals = getEntArray( bombZones[index].target, "targetname" );
+		label = bombZones[index].script_label;
+		collision = getEnt( "dd_bombzone_clip" + label, "targetname" );
+
+		// remove C site from MW3 maps.
+		if ( label == "_c" )
+		{
+			trigger delete();
+			visuals[0] delete();
+			collision delete();
+			continue;
+		}	
 		
 		bombZone = maps\mp\gametypes\_gameobjects::createUseObject( game["defenders"], trigger, visuals, (0,0,64) );
 		bombZone maps\mp\gametypes\_gameobjects::allowUse( "enemy" );


### PR DESCRIPTION
In Demolition, MW3 maps have different bombsite in overtime round, which is not supported by MW2 version of gamemode. This change will remove it.