### PR TITLE
chore: also release zip with all files included

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rawfiles-release
-          path: launcher-files
+          path: temp
 
   release:
     needs:
@@ -67,19 +67,19 @@ jobs:
       - uses: actions/download-artifact@v5
         with:
           name: rawfiles-release
-          path: launcher-files
+          path: temp
       - name: Prepare release tool
         run: |
           wget -O release-tool.tar.gz https://github.com/iw4x/launcher/releases/latest/download/release-tool-x86_64-unknown-linux-gnu.tar.gz
           tar -xvf release-tool.tar.gz
           chmod +x release-tool
       - name: Create release information
-        run: ./release-tool ./launcher-files
+        run: ./release-tool ./temp/launcher-files
       - uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          artifacts: "launcher-files/**/*.*"
+          artifacts: "temp/launcher-files/**/*.*,temp/artifact-files/**/*.*"
           artifactErrorsFailBuild: true
           allowUpdates: true
           draft: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+temp
+zone_out

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,55 +1,85 @@
 #!/bin/bash
 
+###############################################
+# Step 1: Prepare environment
+###############################################
+
 # Exit and fail on first failing command
 set -e
 
 # Check for sudo
 if command -v sudo >/dev/null 2>&1; then SUDO='sudo'; else SUDO=''; fi
 
-# set work_dir to the parent of this scripts location
+# Set work_dir to the parent of this scripts location
 work_dir=$(dirname `cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd`)
 iwd_files=( "iw4x_00" "iw4x_01" "iw4x_02" "iw4x_03" "iw4x_04" "iw4x_05" )
 
-# ensure dependencies are installed
+# Create required dirs
+mkdir -p $work_dir/temp/{zip-files,artifact-files,launcher-files}
+
+# Install required dependencies
 $SUDO apt-get update
 $SUDO apt-get install zip curl -y
 
-# create dirs
-mkdir -p $work_dir/{zip-files,launcher-files}
+###############################################
+# Step 2: Create zip with all compiled rawfiles
+###############################################
 
-# copy artifacts to zip-files dir
-cp iw4x.exe $work_dir/launcher-files/
-cp -r $work_dir/{iw4x,zone} $work_dir/zip-files/
+# Copy artifacts to zip-files dir
+cp -v iw4x.exe $work_dir/temp/zip-files/
+cp -v -r $work_dir/{iw4x,zone} $work_dir/temp/zip-files/
 
-# copy language fast files
-mkdir -p $work_dir/zip-files/zone/patch
-cp $work_dir/zone_out/*/*.ff $work_dir/zip-files/zone/patch/
+# Copy language fast files
+mkdir -p $work_dir/temp/zip-files/zone/patch
+cp -v $work_dir/zone_out/*/*.ff $work_dir/temp/zip-files/zone/patch/
 
-# zip iwd_files
-mkdir -p $work_dir/launcher-files/iw4x
+# Zip iwd_files
+mkdir -p $work_dir/temp/zip-files/iw4x
 for iwd in "${iwd_files[@]}"; do
-    pushd $work_dir/zip-files/iw4x/$iwd
+    pushd $work_dir/temp/zip-files/iw4x/$iwd
     # Set consistent timestamps for all files
     find . -exec touch -t 200001010000.00 {} +
     # Sort files for zipping, -X for deterministic zip
     find . -name '*' -print0 | LC_ALL=C sort -z | xargs -0 zip -X $iwd.zip
-    mv $iwd.zip $work_dir/launcher-files/iw4x/$iwd.iwd
+    mv -v $iwd.zip $work_dir/temp/zip-files/iw4x/$iwd.iwd
     popd
-    rm -r $work_dir/zip-files/iw4x/$iwd
+    rm -r $work_dir/temp/zip-files/iw4x/$iwd
 done
 
-# add zonebuilder-wrapper
-pushd $work_dir/launcher-files/
+# Add zonebuilder-wrapper
+pushd $work_dir/temp/zip-files/
 curl -L https://github.com/iw4x/zonebuilder-wrapper/releases/latest/download/zonebuilder-i686-pc-windows-msvc.zip -o zonebuilder.zip
 unzip zonebuilder.zip
 rm zonebuilder.zip
 popd
 
-# create release.zip from release.zip dir
-pushd $work_dir/zip-files/
+# Create release.zip in artifacts-folder with all rawfiles
+pushd $work_dir/temp/zip-files/
 zip -r -X release.zip *
-mv release.zip $work_dir/launcher-files/
+mv -v $work_dir/temp/zip-files/release.zip $work_dir/temp/artifact-files/release.zip
 popd
 
-# cleanup
-rm -r {zip-files,zone_out}
+###############################################
+# Step 3: Create launcher files
+###############################################
+
+# Move iwd_files to launcher files
+mkdir -p $work_dir/temp/launcher-files/iw4x
+for iwd in "${iwd_files[@]}"; do
+    mv -v $work_dir/temp/zip-files/iw4x/$iwd.iwd $work_dir/temp/launcher-files/iw4x/$iwd.iwd
+done
+
+# Move executable files to launcher files
+mv -v $work_dir/temp/zip-files/{iw4x.exe,zonebuilder.exe} $work_dir/temp/launcher-files/
+
+# Create launcher zip in launcher-folder with all smaller rawfiles
+pushd $work_dir/temp/zip-files/
+zip -r -X __launcher_archive.zip *
+mv -v $work_dir/temp/zip-files/__launcher_archive.zip $work_dir/temp/launcher-files/__launcher_archive.zip
+popd
+
+###############################################
+# Step 4: Cleanup
+###############################################
+
+rm -rf $work_dir/temp/zip-files


### PR DESCRIPTION
I'll also add a feature in another PR to release-tool to rename the standalone to `__launcher<something>` as well, so users are not tempted to download it.

For now this adds back a `release.zip` with all files included.
The archive for the launcher is now called `__launcher_archive.zip`