### PR TITLE
Add net_alwaysUseNodes to prefer node discovery over the master path

### DIFF
--- a/iw4x/iw4x_00/ui_mp/pc_options_multi.menu
+++ b/iw4x/iw4x_00/ui_mp/pc_options_multi.menu
@@ -86,16 +86,17 @@
 
 		PC_OPTIONS_FLOATLIST_RAW(1, "@MENU_MAXPACKETS", "cl_maxpackets", {"30" 30 "100" 100 "125" 125}, ;, "@MENU_DESC_MAXPACKETS", when(0), 1)
 		PC_OPTIONS_FLOATLIST_RAW(2, "@MENU_SNAPS", "snaps", {"20" 20 "30" 30}, ;, "@MENU_DESC_SNAPS", when(0), 1)
+		PC_OPTIONS_DVARYESNO_RAW(3, "@MENU_ALWAYS_USE_NODES", "net_alwaysUseNodes", ;, "@MENU_DESC_ALWAYS_USE_NODES", when(0), 1)
 
-		PC_OPTIONS_SEPERATOR(2)
+		PC_OPTIONS_SEPERATOR(3)
 
-		PC_OPTIONS_DVARYESNO(3, "@MENU_LAGOMETER", "drawLagometer", ;, when(0))
-		PC_OPTIONS_STRLIST_RAW(4, "@MENU_DRAWFPS", "cg_drawFPS", {"Off"; "Off"; "Simple"; "Simple"; "SimpleRanges"; "SimpleRanges"; "Verbose"; "Verbose"; "Verbose+Viewpos"; "Verbose+Viewpos"}, ;, "@MENU_DESC_DRAWFPS", when(0), 1)
-		PC_OPTIONS_DVARYESNO(5, "@MENU_FPSLABELS", "cg_drawFPSLabels", "@MENU_DESC_FPSLABELS", when(0))
+		PC_OPTIONS_DVARYESNO(4, "@MENU_LAGOMETER", "drawLagometer", ;, when(0))
+		PC_OPTIONS_STRLIST_RAW(5, "@MENU_DRAWFPS", "cg_drawFPS", {"Off"; "Off"; "Simple"; "Simple"; "SimpleRanges"; "SimpleRanges"; "Verbose"; "Verbose"; "Verbose+Viewpos"; "Verbose+Viewpos"}, ;, "@MENU_DESC_DRAWFPS", when(0), 1)
+		PC_OPTIONS_DVARYESNO(6, "@MENU_FPSLABELS", "cg_drawFPSLabels", "@MENU_DESC_FPSLABELS", when(0))
 
-		PC_OPTIONS_SEPERATOR(5)
+		PC_OPTIONS_SEPERATOR(6)
 
-		PC_OPTIONS_DVARYESNO_RAW(6, "@MENU_STREAMFRIENDLY_UI", "ui_streamFriendly", ;, "@MPUI_DESC_STREAM_FRIENDLY_UI", when(0), 1)
-		PC_OPTIONS_DVARYESNO(7, "@MENU_FRIENDNOTIFY", "cl_notifyFriendState", "@MPUI_DESC_FRIENDNOTIFY", when(0))
+		PC_OPTIONS_DVARYESNO_RAW(7, "@MENU_STREAMFRIENDLY_UI", "ui_streamFriendly", ;, "@MPUI_DESC_STREAM_FRIENDLY_UI", when(0), 1)
+		PC_OPTIONS_DVARYESNO(8, "@MENU_FRIENDNOTIFY", "cl_notifyFriendState", "@MPUI_DESC_FRIENDNOTIFY", when(0))
 	}
 }

--- a/zone_raw/iw4x_localized_english/english/localizedstrings/iw4x_localized_english.str
+++ b/zone_raw/iw4x_localized_english/english/localizedstrings/iw4x_localized_english.str
@@ -173,6 +173,12 @@ LANG_ENGLISH        "Maximum number of packets sent per frame"
 REFERENCE           MENU_DESC_SNAPS
 LANG_ENGLISH        "Snapshot rate"
 
+REFERENCE           MENU_ALWAYS_USE_NODES
+LANG_ENGLISH        "Always use node system"
+
+REFERENCE           MENU_DESC_ALWAYS_USE_NODES
+LANG_ENGLISH        "Always use node system instead of master server (useful for regions with connection restrictions)"
+
 REFERENCE           MENU_DESC_THUMBSTICK_LAYOUT
 LANG_ENGLISH        "Change the thumbstick layout for the gamepad"
 


### PR DESCRIPTION
We accommodates a now familiar pattern in parts of Russia where traffic to the OVH-hosted master is intermittently filtered or de-prioritized by authorities/regional carriers. Through no particular engineering of ours, Node discovery tends to slip through unaffected, a small mercy, all things considered.