### PR TITLE
chore: add a link to Unlinker source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ These are the rawfiles that are required (next to iw4x.dll) to launch and play I
 # Building
 
 Almost all the **fastfiles** in this repo are already compiled and available for use by IW4x. Likewise, as stated above, the **IWDs** can be built using the provided build scripts found under the `scripts` folder. However, some fastfiles are easy to reproduce, and to simplify development, the language fastfiles are built using [OAT](https://github.com/Laupetin/OpenAssetTools). The repository already has these files set up in the correct folders so that OAT can read them and generate the language fastfiles. See [ci.yml](.github/workflows/ci.yml) for more information.
+
+# Further information
+
+## Unlinker.exe
+
+Used to convert fastfiles from the x64 game version to x86 for IW4x to be able to use them.
+It is licensed under GPLv3 and its source code for it can be found [here](https://github.com/iw4x-x64/oat).


### PR DESCRIPTION
Since the repository containing the source is not under the same organization as this repository, this links it to make sure it can be found.
So people are not under the impression this is a binary without source released 😅 